### PR TITLE
fix: do not change population on destroy

### DIFF
--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -317,7 +317,6 @@ auto engine_t::prototype() -> std::unique_ptr<io::basic_dispatch_t> {
 auto engine_t::cancel() -> void {
     this->stats.deregister();
     this->stopped = true;
-    this->control_population(boost::none);
     this->pool->clear();
     this->on_spawn_rate_timer->reset();
     this->on_postmortem_timer->reset();


### PR DESCRIPTION
When engine is stopped there is no need to change population.