### PR TITLE
Move isolate instance out of repository to app_t class.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.14.69) unstable; urgency=low
+
+  * Fixed: hold copy of isolate object in app_t, along with app's io loop,
+    instead of repository cache.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Tue, 14 Aug 2018 11:27:18 +0300
+
 cocaine-plugins (0.12.14.68) unstable; urgency=low
 
   * refact: Data structs in vicodyn dispatcher

--- a/node/include/cocaine/detail/service/node/slave.hpp
+++ b/node/include/cocaine/detail/service/node/slave.hpp
@@ -48,6 +48,7 @@ public:
             manifest_t manifest,
             profile_t profile,
             std::shared_ptr<api::authentication_t> auth,
+            const std::shared_ptr<api::isolate_t>& isolate,
             asio::io_service& loop,
             cleanup_handler fn);
     slave_t(const slave_t& other) = delete;

--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -13,6 +13,7 @@
 #include <metrics/metric.hpp>
 #include <metrics/usts/ewma.hpp>
 
+#include <cocaine/forwards.hpp>
 #include <cocaine/logging.hpp>
 
 #include "cocaine/idl/rpc.hpp"
@@ -63,7 +64,7 @@ public:
 
 private:
     const std::unique_ptr<cocaine::logging::logger_t> log;
-
+    const std::shared_ptr<api::isolate_t> isolate_;
 public:
     context_t& context;
 
@@ -127,6 +128,7 @@ public:
               manifest_t manifest,
               profile_t profile,
               std::shared_ptr<api::authentication_t> auth,
+              const std::shared_ptr<api::isolate_t>& isolate,
               asio::io_service& loop,
               cleanup_handler cleanup);
 
@@ -172,6 +174,8 @@ public:
     auto
     uptime() const -> std::chrono::seconds;
 
+    auto
+    isolate() -> api::isolate_t&;
 private:
     void
     output(const char* data, size_t size);

--- a/node/include/cocaine/repository/isolate.hpp
+++ b/node/include/cocaine/repository/isolate.hpp
@@ -30,6 +30,9 @@
 namespace cocaine {
 namespace api {
 
+///
+/// Repository's class default_factory implementation for `isolate_t`.
+///
 template<>
 struct category_traits<isolate_t> {
     typedef isolate_ptr ptr_type;
@@ -45,22 +48,8 @@ struct category_traits<isolate_t> {
         virtual
         ptr_type
         get(context_t& context, asio::io_service& io_context, const std::string& name, const std::string& type, const dynamic_t& args) {
-            ptr_type instance;
-
-            instances.apply([&](std::map<std::string, std::weak_ptr<isolate_t>>& instances) {
-                auto weak_ptr = instances[name];
-
-                if ((instance = weak_ptr.lock()) == nullptr) {
-                    instance = std::make_shared<T>(context, io_context, name, type, args);
-                    instances[name] = instance;
-                }
-            });
-
-            return instance;
+            return std::make_shared<T>(context, io_context, name, type, args);
         }
-
-    private:
-        synchronized<std::map<std::string, std::weak_ptr<isolate_t>>> instances;
     };
 };
 

--- a/node/include/cocaine/service/node/app.hpp
+++ b/node/include/cocaine/service/node/app.hpp
@@ -6,6 +6,8 @@
 
 #include <boost/thread/thread.hpp>
 
+#include <cocaine/forwards.hpp>
+
 #include "cocaine/common.hpp"
 #include "cocaine/idl/node.hpp"
 #include "cocaine/rpc/slot/deferred.hpp"
@@ -30,10 +32,15 @@ private:
     std::unique_ptr<boost::thread> thread;
     std::shared_ptr<app_state_t> state;
 
+    // Isolate uses this->loop for internal mechanics, so loop should be
+    // still alive on isolate destruction. It is also stored as shared_ptr, not
+    // unique_ptr, because it must be alive (along with loop) in engine_t, as
+    // engine_t could outlive app_t (such behaviour could be changed someday).
+    std::shared_ptr<api::isolate_t> isolate_;
 public:
     app_t(context_t& context,
           const std::string& manifest,
-          const std::string& profile,
+          const std::string& profile_name,
           std::function<void(std::future<void> future)> callback);
     ~app_t();
 

--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -4,6 +4,7 @@
 
 #include <boost/optional.hpp>
 
+#include <cocaine/forwards.hpp>
 #include <cocaine/rpc/dispatch.hpp>
 
 #include "cocaine/idl/node.hpp"
@@ -30,6 +31,7 @@ public:
                manifest_t manifest,
                profile_t profile,
                std::shared_ptr<pool_observer> observer,
+               const std::shared_ptr<api::isolate_t>& isolate,
                std::shared_ptr<asio::io_service> loop);
 
     /// TODO: Docs.

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/optional.hpp>
 
+#include <cocaine/forwards.hpp>
 #include <cocaine/rpc/dispatch.hpp>
 
 #include "cocaine/idl/node.hpp"
@@ -78,6 +79,8 @@ public:
     /// Statistics.
     stats_t stats;
 
+    const std::shared_ptr<api::isolate_t> isolate_;
+
     /// Isolation daemon's workers metrics sampler.
     /// Poll sequence should be initialized explicitly with
     /// metrics_retriever_t::ignite_poll method or implicitly
@@ -88,6 +91,7 @@ public:
              manifest_t manifest,
              profile_t profile,
              std::shared_ptr<pool_observer> observer,
+             const std::shared_ptr<api::isolate_t>& isolate,
              std::shared_ptr<asio::io_service> loop);
 
     ~engine_t();

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -21,8 +21,9 @@ overseer_t::overseer_t(context_t& context,
                        manifest_t manifest,
                        profile_t profile,
                        std::shared_ptr<pool_observer> observer,
+                       const std::shared_ptr<api::isolate_t>& isolate,
                        std::shared_ptr<asio::io_service> loop)
-    : engine(std::make_shared<engine_t>(context, manifest, profile, observer, loop))
+    : engine(std::make_shared<engine_t>(context, manifest, profile, observer, isolate, loop))
 {
     try {
         engine->start_isolate_metrics_poll();

--- a/node/src/node/slave.cpp
+++ b/node/src/node/slave.cpp
@@ -12,8 +12,6 @@
 #include <cocaine/rpc/actor.hpp>
 #include <cocaine/rpc/upstream.hpp>
 
-#include "cocaine/api/isolate.hpp"
-
 #include "cocaine/service/node/manifest.hpp"
 #include "cocaine/service/node/profile.hpp"
 
@@ -40,10 +38,11 @@ slave_t::slave_t(context_t& context,
                  manifest_t manifest,
                  profile_t profile,
                  std::shared_ptr<api::authentication_t> auth,
+                 const std::shared_ptr<api::isolate_t>& isolate,
                  asio::io_service& loop,
                  cleanup_handler fn)
     : ec(error::overseer_shutdowning),
-      machine(std::make_shared<machine_t>(context, id, manifest, profile, std::move(auth), loop, fn))
+      machine(std::make_shared<machine_t>(context, id, manifest, profile, std::move(auth), isolate, loop, fn))
 {
     machine->start();
 


### PR DESCRIPTION
  Move external_t instance from Cocaine global registry to app_t's
class member as a shared pointer (also store it into engine_t).

**TODO:**
 - [x] more testing needed.
 - [x] version bump.