### PR TITLE
Fix: recreate uniresis node if it not exists on subscription

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.14.70) unstable; urgency=medium
+
+  * Fixed(uniresis): start node create sequence in case of `not exist`
+    error in subscription.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Tue, 21 Aug 2018 18:42:46 +0300
+
 cocaine-plugins (0.12.14.69) unstable; urgency=low
 
   * Fixed: hold copy of isolate object in app_t, along with app's io loop,


### PR DESCRIPTION
 - recreate uniresis node in case it is reported with version == `not_existing_version`.
  - subscribe, if node already exist on create, report a warning, but don't continue with notify_later sequence.