### PR TITLE
 feat: Metrics about choice of peers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.14.76) unstable; urgency=low
+
+  * feat: Metrics about choice of peers
+
+ -- Artem Selishchev <arselishev@gmail.com>  Thu, 30 Aug 2018 16:52:34 +0300
+
 cocaine-plugins (0.12.14.75) unstable; urgency=low
 
   * fix: Print weights of peers for 'vicodyn::apps' request

--- a/vicodyn/src/vicodyn/peer.cpp
+++ b/vicodyn/src/vicodyn/peer.cpp
@@ -70,6 +70,7 @@ peer_t::peer_t(context_t& context, asio::io_service& loop, endpoints_t endpoints
     loop_(loop),
     timer_(loop),
     logger_(context.log(format("vicodyn_peer/{}", uuid))),
+    meter_(context.metrics_hub().meter(format("vicodyn.peers.{}.attempts", uuid))),
     d_{
         std::move(uuid),
         std::move(endpoints),


### PR DESCRIPTION
Example:
```json
{
    "vicodyn.peers.04f05e7d-881c-4eda-b4ab-a29b52bbf668.attempts.count": 539, 
    "vicodyn.peers.04f05e7d-881c-4eda-b4ab-a29b52bbf668.attempts.m01rate": 3.28362103041947, 
    "vicodyn.peers.04f05e7d-881c-4eda-b4ab-a29b52bbf668.attempts.m05rate": 1.315685773912181, 
    "vicodyn.peers.04f05e7d-881c-4eda-b4ab-a29b52bbf668.attempts.m15rate": 0.5360444899422733, 
    "vicodyn.peers.4c10e9d9-5fdf-4716-bd5f-36f3247ad4cd.attempts.count": 507, 
    "vicodyn.peers.4c10e9d9-5fdf-4716-bd5f-36f3247ad4cd.attempts.m01rate": 3.0106314968717953, 
    "vicodyn.peers.4c10e9d9-5fdf-4716-bd5f-36f3247ad4cd.attempts.m05rate": 1.2229893944279129, 
    "vicodyn.peers.4c10e9d9-5fdf-4716-bd5f-36f3247ad4cd.attempts.m15rate": 0.5019415668948017
}
```