### PR TITLE
Fix: external connect crash

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -101,7 +101,7 @@ set(BUILD_FLAGS "${BUILD_FLAGS} -Wold-style-cast")
 set(BUILD_FLAGS "${BUILD_FLAGS} -Woverloaded-virtual")
 set(BUILD_FLAGS "${BUILD_FLAGS} -Wswitch")
 set(BUILD_FLAGS "${BUILD_FLAGS} -Wunreachable-code")
-set(BUILD_FLAGS "${BUILD_FLAGS} -pedantic -pedantic-errors")
+set(BUILD_FLAGS "${BUILD_FLAGS} -pedantic")
 
 set_target_properties(${PLUGIN_NAME} PROPERTIES
     COMPILE_FLAGS "${BUILD_FLAGS}"


### PR DESCRIPTION
There is two async. handlers in `external_t::inner_t::connect`, one for connection, another for connection timeout, latter cancel's the socket, which happen to be unique pointer, the former cancels the timer and resets socket to null on error. But according to the `boost::deadline_timer` [documentation](https://www.boost.org/doc/libs/1_46_1/doc/html/boost_asio/reference/basic_deadline_timer/cancel/overload1.html#boost_asio.reference.basic_deadline_timer.cancel.overload1.remarks)

```
Remarks

If the timer has already expired when cancel() is called, then the handlers for asynchronous wait operations will:

  -   have already been invoked; or
  -   have been queued for invocation in the near future.

These handlers can no longer be cancelled, and therefore are passed an error code that indicates the successful completion of the wait operation. 

```

### TODO:
 - [x] description of race.
 - [x] basic testing.